### PR TITLE
Fixing the page titles for each of the docs

### DIFF
--- a/legacy-docs/pages/customization.mdx
+++ b/legacy-docs/pages/customization.mdx
@@ -1,3 +1,7 @@
+---
+title: Customize Styles
+---
+
 # Customize Styles
 Style props are exposed for you to customize the look and feel of your guestbook.
 ## Props

--- a/legacy-docs/pages/index.mdx
+++ b/legacy-docs/pages/index.mdx
@@ -1,3 +1,6 @@
+---
+title: Introduction
+---
 import Callout from "nextra-theme-docs/callout";
 
 # Introducing Legacy XYZ

--- a/legacy-docs/pages/install.mdx
+++ b/legacy-docs/pages/install.mdx
@@ -1,3 +1,6 @@
+---
+title: Install
+---
 import Callout from 'nextra-theme-docs/callout'
 
 # How to install

--- a/legacy-docs/pages/troubleshooting.mdx
+++ b/legacy-docs/pages/troubleshooting.mdx
@@ -1,3 +1,6 @@
+---
+title: Troubleshooting
+---
 # Troubleshooting
 Some common issues include:
 - integrating with Next.js requires explicitly enabling browswer side rendering


### PR DESCRIPTION
Hi! Small change, I just saw that all the page titles for the docs were 
`Untitled + titleSuffix` so I wanted to dig a bit and fix it. 

**Before**

<img width="300" alt="Screen Shot 2022-01-26 at 10 03 58 PM" src="https://user-images.githubusercontent.com/24577817/151296220-40f316e9-ecc3-4cd3-b39c-e9242e848246.png">

**After**

<img width="300" alt="Screen Shot 2022-01-26 at 10 04 08 PM" src="https://user-images.githubusercontent.com/24577817/151296264-92bfb274-8306-4ffc-912e-661a1833c3c0.png">



Hope it helps :)